### PR TITLE
mata: Use Clang 9.0.2 for kernel

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -179,7 +179,7 @@ TARGET_KERNEL_SOURCE := kernel/essential/msm8998
 TARGET_KERNEL_CONFIG := artemis_mata_defconfig
 TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
 TARGET_KERNEL_CLANG_COMPILE := true
-TARGET_KERNEL_CLANG_VERSION := 9.0
+TARGET_KERNEL_CLANG_VERSION := 9.0.2
 export CROSS_COMPILE_ARM32 = prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-
 
 # IPA


### PR DESCRIPTION
Signed-off-by: celtare21 <celtare21@gmail.com>