### PR TITLE
mata: Downgrade to Clang 8.0.9

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -174,7 +174,7 @@ TARGET_KERNEL_SOURCE := kernel/essential/msm8998
 TARGET_KERNEL_CONFIG := artemis_mata_defconfig
 TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
 TARGET_KERNEL_CLANG_COMPILE := true
-TARGET_KERNEL_CLANG_VERSION := 9.0.2
+TARGET_KERNEL_CLANG_VERSION := 8.0.9
 export CROSS_COMPILE_ARM32 = prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-
 
 # IPA


### PR DESCRIPTION
Version 9.0.x of LLVM has a performance regressions,
revert to the older version of clang for now.

Signed-off-by: celtare21 <celtare21@gmail.com>