### PR TITLE
mata: Set VOICE_SPEAKER_DMIC to use ACDB ID 132

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -40,6 +40,7 @@
         <device name="SND_DEVICE_IN_UNPROCESSED_THREE_MIC" acdb_id="145"/>
         <device name="SND_DEVICE_IN_UNPROCESSED_QUAD_MIC" acdb_id="146"/>
         <device name="SND_DEVICE_IN_UNPROCESSED_HEADSET_MIC" acdb_id="147"/>
+        <device name="SND_DEVICE_IN_VOICE_SPEAKER_DMIC" acdb_id="132"/>
     </acdb_ids>
     <bit_width_configs>
         <device name="SND_DEVICE_OUT_SPEAKER" bit_width="24"/>


### PR DESCRIPTION
* ACDB ID 132 is used for Fluence dual mic voice recognition
* Intended to address issue #2209

Change-Id: I68ee69a604eaab433825d31ff4e50a07fb4e8b60